### PR TITLE
Disposing graphic resources from icon building

### DIFF
--- a/Crycker/Helper/TaskbarIconHelper.cs
+++ b/Crycker/Helper/TaskbarIconHelper.cs
@@ -12,12 +12,17 @@ namespace Crycker.Helper
         public static bool DarkMode { get; set; }
         public static bool Highlight { get; set; }
 
-        private static string fontName;
+        private static readonly Font font;
 
         static TaskbarIconHelper()
         {
             var settings = Settings.UserSettings.Load();
-            fontName = settings.FontName;
+            font = new Font(settings.FontName, 7);
+            if (String.Compare(settings.FontName, font.Name, StringComparison.InvariantCultureIgnoreCase) != 0)
+            {
+                Logger.Warning($"Font '{settings.FontName}' not found, '{font.Name}' selected. Backing down to 'Tahoma'.");
+                font = new Font("Tahoma", 7);
+            }
         }
 
         public static void SetPrice(decimal lastPrice, decimal previousPrice, string coin, string currency, string provider, DateTime lastUpdated)
@@ -38,13 +43,6 @@ namespace Crycker.Helper
 
             var bitmap = new Bitmap(16, 16);
             var graphics = Graphics.FromImage(bitmap);
-            var font = new Font(fontName, 7);
-
-            if (String.Compare(fontName, font.Name, StringComparison.InvariantCultureIgnoreCase) != 0)
-            {
-                Logger.Warning($"Font '{fontName}' not found, '{font.Name}' selected. Backing down to 'Tahoma'.");
-                font = new Font("Tahoma", 7);
-            }
 
             // graphics.FillRectangle(Brushes.White, new Rectangle(0, 0, 16, 16));
 

--- a/Crycker/Helper/TaskbarIconHelper.cs
+++ b/Crycker/Helper/TaskbarIconHelper.cs
@@ -37,56 +37,60 @@ namespace Crycker.Helper
                 if (percentChange != 0)
                 {
                     Color priceColor = (percentChange >= 0) ? Color.Green : Color.OrangeRed;
+                    brush.Dispose();
                     brush = new SolidBrush(priceColor);
                 }
             }
 
-            var bitmap = new Bitmap(16, 16);
-            var graphics = Graphics.FromImage(bitmap);
-
-            // graphics.FillRectangle(Brushes.White, new Rectangle(0, 0, 16, 16));
-
-            string line1;
-            string line2;
-
-            if (lastPrice == 0)
+            using (var bitmap = new Bitmap(16, 16))
+            using (var graphics = Graphics.FromImage(bitmap))
             {
-                line1 = "?";
-                line2 = "";
-            } else if (lastPrice < 1)
-            {                
-                var s = lastPrice.ToString("F3").Split(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator[0]);
-                line1 = s[0];
-                line2 = s[1];
-            } else if (lastPrice > 1000)
-            {
-                var s = lastPrice.ToString("F0");
-                if (s.Length > 5) s = s.Substring(0, 6);
-                line1 = s.Substring(0, s.Length / 2);
-                line2 = s.Substring(s.Length / 2);
+                // graphics.FillRectangle(Brushes.White, new Rectangle(0, 0, 16, 16));
+
+                string line1;
+                string line2;
+
+                if (lastPrice == 0)
+                {
+                    line1 = "?";
+                    line2 = "";
+                }
+                else if (lastPrice < 1)
+                {
+                    var s = lastPrice.ToString("F3").Split(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator[0]);
+                    line1 = s[0];
+                    line2 = s[1];
+                }
+                else if (lastPrice > 1000)
+                {
+                    var s = lastPrice.ToString("F0");
+                    if (s.Length > 5) s = s.Substring(0, 6);
+                    line1 = s.Substring(0, s.Length / 2);
+                    line2 = s.Substring(s.Length / 2);
+                }
+                else
+                {
+                    var s = lastPrice.ToString("F2").Split(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator[0]);
+                    line1 = s[0];
+                    line2 = s[1];
+                }
+
+                var m = graphics.MeasureString(line1, font);
+                var w2 = (int)Math.Round(m.Width / 2);
+                var h2 = (int)Math.Round(m.Height / 2);
+
+                graphics.DrawString(line1, font, brush, bitmap.Size.Width / 2 - w2, -4 + bitmap.Size.Height / 2 - h2);
+
+                m = graphics.MeasureString(line2, font);
+                w2 = (int)Math.Round(m.Width / 2);
+                h2 = (int)Math.Round(m.Height / 2);
+                graphics.DrawString(line2, font, brush, bitmap.Size.Width / 2 - w2, 5 + bitmap.Size.Height / 2 - h2);
+
+                var hIcon = bitmap.GetHicon();
+                var icon = Icon.FromHandle(hIcon);
+                notifyIcon.Icon = icon;
             }
-            else
-            {
-                var s = lastPrice.ToString("F2").Split(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator[0]);
-                line1 = s[0];
-                line2 = s[1];
-            }
-
-            var m = graphics.MeasureString(line1, font);
-            var w2 = (int)Math.Round(m.Width / 2);
-            var h2 = (int)Math.Round(m.Height / 2);
-
-            graphics.DrawString(line1, font, brush, bitmap.Size.Width / 2 - w2, -4 + bitmap.Size.Height / 2 - h2);
-
-            m = graphics.MeasureString(line2, font);
-            w2 = (int)Math.Round(m.Width / 2);
-            h2 = (int)Math.Round(m.Height / 2);
-            graphics.DrawString(line2, font, brush, bitmap.Size.Width / 2 - w2, 5 + bitmap.Size.Height / 2 - h2);
-
-            var hIcon = bitmap.GetHicon();
-            var icon = Icon.FromHandle(hIcon);            
-            notifyIcon.Icon = icon;
-
+            brush.Dispose();
             notifyIcon.Text = $"{provider} {coin}/{currency}: {lastPrice} ({percentChange:N2}%) @ {lastUpdated.ToLongTimeString()}";
         }        
     }

--- a/Crycker/Helper/TaskbarIconHelper.cs
+++ b/Crycker/Helper/TaskbarIconHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace Crycker.Helper
@@ -25,8 +26,14 @@ namespace Crycker.Helper
             }
         }
 
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern bool DestroyIcon(IntPtr handle);
+
+        private static IntPtr lastIcon;
+
         public static void SetPrice(decimal lastPrice, decimal previousPrice, string coin, string currency, string provider, DateTime lastUpdated)
         {
+            DestroyIcon(lastIcon);
             var percentChange = 0.0M;
             var brush = new SolidBrush(DarkMode ? Color.White : Color.Black);
 
@@ -86,9 +93,9 @@ namespace Crycker.Helper
                 h2 = (int)Math.Round(m.Height / 2);
                 graphics.DrawString(line2, font, brush, bitmap.Size.Width / 2 - w2, 5 + bitmap.Size.Height / 2 - h2);
 
-                var hIcon = bitmap.GetHicon();
-                var icon = Icon.FromHandle(hIcon);
-                notifyIcon.Icon = icon;
+                lastIcon = bitmap.GetHicon();
+                var icon = Icon.FromHandle(lastIcon);
+                notifyIcon.Icon = icon;                
             }
             brush.Dispose();
             notifyIcon.Text = $"{provider} {coin}/{currency}: {lastPrice} ({percentChange:N2}%) @ {lastUpdated.ToLongTimeString()}";


### PR DESCRIPTION
With 15 seconds interval, the application could would crash after approximately 12 hours. I did this today, so I'm not sure if it really fixes, but disposing resources is a good pratice anyway.
See: https://stackoverflow.com/questions/12026664/a-generic-error-occurred-in-gdi-when-calling-bitmap-gethicon